### PR TITLE
add latchedlabel config property to act similar to latchedlogo

### DIFF
--- a/FTButton.h
+++ b/FTButton.h
@@ -52,12 +52,14 @@ namespace FreeTouchDeck
         uint8_t TextSize = 0;
         uint32_t TextColor = 0;
         std::string Label;
+        std::string LatchedLabel;
         static void InitConstants();
 
         static const char *JsonLabelLogo;
         static const char *JsonLabelLatchedLogo;
         static const char *JsonLabelType;
         static const char *JsonLabelLabel;
+        static const char *JsonLabelLatchedLabel;
         static const char *JsonLabelActions;
         static const char *JsonLabelOutline;
         static const char *JsonLabelBackground;
@@ -71,7 +73,7 @@ namespace FreeTouchDeck
         FTButton(cJSON *button);
         FTButton();
         FTButton(cJSON *button, uint32_t BackgroundColor, uint32_t Outline, uint32_t TextColor);
-        FTButton(ButtonTypes buttonType, const char *label, const char *logo, const char *latchedLogo, uint32_t outline, uint8_t textSize, uint32_t textColor);
+        FTButton(ButtonTypes buttonType, const char *label, const char *latchedLabel, const char *logo, const char *latchedLogo, uint32_t outline, uint8_t textSize, uint32_t textColor);
         void Init(cJSON *button);
         FTButton(const char *tmpl, bool isShared = false);
         static FTButton *BackButton;

--- a/ImageCache.cpp
+++ b/ImageCache.cpp
@@ -66,7 +66,7 @@ namespace FreeTouchDeck
         ImageInstanceGet_t constructor = GetConstructorForImage(imageName);
         if (!constructor)
         {
-            LOC_LOGE(module, "Unsupported file format %s", ImageWrapper::GetExtension(imageName).c_str());
+            LOC_LOGE(module, "Unsupported %s file format %s", imageName.c_str(), ImageWrapper::GetExtension(imageName).c_str());
             return ImageList.front();
         }
         else

--- a/MenuNavigation.cpp
+++ b/MenuNavigation.cpp
@@ -393,7 +393,7 @@ namespace FreeTouchDeck
                 if (menu->Type == MenuTypes::HOME || menu->Type == MenuTypes::HOMESYSTEM)
                 {
                     LOC_LOGD(module,"Creating home screen button for menu %s", menu->Label.c_str());
-                    auto button = FTButton(ButtonTypes::STANDARD, menu->Label.c_str(), menu->Icon.c_str(), "", generalconfig.DefaultOutline, generalconfig.DefaultTextSize, generalconfig.DefaultTextColor);
+                    auto button = FTButton(ButtonTypes::STANDARD, menu->Label.c_str(), "", menu->Icon.c_str(), "", generalconfig.DefaultOutline, generalconfig.DefaultTextSize, generalconfig.DefaultTextColor);
                     ActionsSequences sequences;
                     char *menuActionString = (char *)malloc_fn(strlen(MenuActionTemplate) + menu->Name.length());
                     sprintf(menuActionString, MenuActionTemplate, menu->Name.c_str());


### PR DESCRIPTION
Update for the development branch.

Currently you can swap logos on a latched button depending on its
latched state, but the new ability to use labels does not have a
parallel feature.