### PR TITLE
add "memstatsdelay" configuration to reduce mem stats print to serial

### DIFF
--- a/ConfigLoad.cpp
+++ b/ConfigLoad.cpp
@@ -98,6 +98,7 @@ namespace FreeTouchDeck
     generalconfig.deviceName = ps_strdup(defaultDeviceName);
     FREE_AND_NULL(generalconfig.manufacturer);
     generalconfig.manufacturer = ps_strdup(defaultManufacturerName);
+    generalconfig.memStatsDelay = 5000;
   }
 
   bool GetValueOrDefault(cJSON *value, char **valuePointer, const char *defaultValue)
@@ -464,6 +465,8 @@ namespace FreeTouchDeck
     GetValueOrDefault(cJSON_GetObjectItem(doc, "ledbrightness"), (uint8_t *)&generalconfig.ledBrightness, 255);
     GetValueOrDefault(cJSON_GetObjectItem(doc, "textsize"), &generalconfig.DefaultTextSize, KEY_TEXTSIZE);
 
+    GetValueOrDefault(cJSON_GetObjectItem(doc, "memstatsdelay"), &generalconfig.memStatsDelay, 5000);
+
     cJSON_Delete(doc);
 
     if (generalconfig.LogLevel >= LogLevels::VERBOSE)
@@ -567,6 +570,7 @@ namespace FreeTouchDeck
     cJSON_AddNumberToObject(doc, "keydelay", generalconfig.keyDelay);
     cJSON_AddNumberToObject(doc, "ledbrightness", generalconfig.ledBrightness);
     cJSON_AddNumberToObject(doc, "textsize", generalconfig.DefaultTextSize);
+    cJSON_AddNumberToObject(doc, "memstatsdelay", generalconfig.memStatsDelay);
     return doc;
   }
   bool saveConfig(bool serial)

--- a/ConfigLoad.h
+++ b/ConfigLoad.h
@@ -39,6 +39,7 @@ namespace FreeTouchDeck
         uint16_t helperdelay;
         uint8_t ledBrightness;
         LogLevels LogLevel;
+        uint16_t memStatsDelay;
     };
     extern Config generalconfig;
     bool GetValueOrDefault(cJSON *value, char **valuePointer, const char *defaultValue);

--- a/System.cpp
+++ b/System.cpp
@@ -254,11 +254,14 @@ namespace FreeTouchDeck
     }
     void PrintMemStats()
     {
+        if (generalconfig.memStatsDelay == 0) {
+            return;
+        }
         static unsigned long t = 0;
         if(millis() >t)
         {
             PrintBasicMemInfo();
-            t=millis()+5000;
+            t=millis()+generalconfig.memStatsDelay;
         }
     }
     void PrintBasicMemInfo()


### PR DESCRIPTION
Changes for the development branch

Currently the memory stats are printed to the serial every 5s.  The
information is useful when debugging memory issues, but can get in
the way when debugging other issues.  This allows for a
"memstatusdelay" generalconfig option to change the frequency the
memory stats are printed, the value is in milliseconds (default value stays
5000).  To disable the memory stats print entirely you can set the value
to "0"